### PR TITLE
Makefile,install_box*.sh: normalize build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ _testmain.go
 *.exe
 *.test
 *.prof
+
+bin

--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,17 @@ all: test
 install_box:
 	@sh install_box.sh
 
-build: install_box
-	box -t unclejack/tarutil build.rb	
+install_box_ci:
+	@sh install_box_ci.sh
 
-test: build
-	docker run -it unclejack/tarutil
+build: 
+	PATH=${PATH}:${PWD}/bin box -t unclejack/tarutil build.rb	
+
+run_test:
+	docker run unclejack/tarutil
+
+test: install_box build run_test
+
+test-ci: install_box_ci build run_test
 
 .PHONY: build install_box

--- a/install_box.sh
+++ b/install_box.sh
@@ -5,5 +5,5 @@ set -e
 if [ "x$(which box)" = "x" ]
 then
   echo "Installing erikh/box to build docker images; may require sudo password."
-  curl -sSL https://raw.githubusercontent.com/erikh/box/master/install.sh | sudo bash
+  curl -sSL box-builder.sh | bash
 fi

--- a/install_box_ci.sh
+++ b/install_box_ci.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -e
+
+if [ ! -x bin/box ]
+then
+  mkdir -p bin
+  curl -sSL https://github.com/erikh/box/releases/download/v0.5.1/box-0.5.1.linux.gz | gzip -dc >bin/box
+  chmod +x bin/box
+fi


### PR DESCRIPTION
* box installer no longer requires sudo (the installer figures that out itself now)
* new test-ci target for installing box and testing in CI.

Signed-off-by: Erik Hollensbe <github@hollensbe.org>