### PR TITLE
unpack.go: remove whiteout handling from unpack

### DIFF
--- a/unpack.go
+++ b/unpack.go
@@ -296,12 +296,6 @@ func Unpack(ctx context.Context, r io.Reader, dest string, options *Options) err
 		}
 
 		fullPath := filepath.Join(dest, hdr.Name)
-		base := filepath.Base(fullPath)
-
-		if strings.HasPrefix(base, whiteoutPrefix) {
-			handleWhiteouts(fullPath, unpackedPaths)
-			continue
-		}
 
 		if hdr.Name != "/" && hdr.Name != "." {
 			if err := handleTarEntry(targetPaths, fullPath, dest, hdr, tr, options); err != nil {


### PR DESCRIPTION
This isn't needed here. It needs to be used only in some cases when we need to apply the changes.